### PR TITLE
feat: add Tableau_Dashboard markdown with Google Slides URL

### DIFF
--- a/Tableau_Dashboard/Tableau_Dashboard.md
+++ b/Tableau_Dashboard/Tableau_Dashboard.md
@@ -1,0 +1,12 @@
+# **Welcome to the Austin AniML Rescue Tableau Dashboard Section!**
+- The preliminary stages of the Tableau Dashboard and Google Slides Storyboard has been developed by Melinda Malone
+
+## Google Slides Storyboard
+The Google Slides Storyboard can be accessed [here](https://docs.google.com/presentation/d/1I76xwzYE5ayG0caMRfxuqka7FQG8sYJ4AU3SiddDGRE/edit#slide=id.p).
+
+## Austin AniML Rescue in Tableau Public
+[Tableau Public](https://public.tableau.com/en-us/s/) will be the data visualization tool used to create the final dashboard for the Austin AniML Rescue machine learning project.
+
+Tableau is an interactive data visualization software harnessing business intelligence to simplify raw data into easily understandable worksheets, dashboards, and stories. Therefore our data project team chose Tableau as the dashboard because of its immersive interactive platform.  To capitalize on Tableau’s interactivity, several filters, color marks, quick table calculations, and other Tableau features have been added to the Austin AniML Rescue dashboard. These enhanced features allow the user to drilldown by animal type, breed, intake type, outcome type, etc.
+
+The preliminary Austin_AniML_Rescue Tableau viz can be located [here](https://public.tableau.com/app/profile/melinda.malone/viz/Austin_AniML_Rescue). 


### PR DESCRIPTION
This is the Tableau Dashboard markdown file that includes URL to Google Slides for Storyboard outlining tools used and interactive elements in final dashboard.